### PR TITLE
Not working yet - Update for InkScape 1.0

### DIFF
--- a/Lasercut-jigsaw.inx
+++ b/Lasercut-jigsaw.inx
@@ -1,51 +1,53 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <inkscape-extension xmlns="http://www.inkscape.org/namespace/inkscape/extension">
-	<_name>Lasercut Jigsaw</_name>
-	<id>org.inkscape.render.LasercutJigsaw</id>
-	<dependency type="executable" location="extensions">Lasercut-jigsaw.py</dependency>
-	<dependency type="executable" location="extensions">inkex.py</dependency>
-	<param name="tab" type="notebook">
-		<page name="Dimensions" _gui-text="Dimensions">
-			<_param name="laserjigdim" type="description"  xml:space="preserve">Dimensions:
+    <_name>Lasercut Jigsaw</_name>
+    <id>fablabchemnitz.de.lasercut_jigsaw</id>
+    <dependency type="executable" location="extensions">fablabchemnitz_lasercut_jigsaw.py</dependency>
+    <dependency type="executable" location="extensions">inkex.py</dependency>
+    <param name="tab" type="notebook">
+        <page name="Dimensions" _gui-text="Dimensions">
+            <_param name="laserjigdim" type="description" xml:space="preserve">Dimensions:
 Define the Jigsaw size and grid size.
 			</_param>
-			<param name="width"  type="float" min="0.1" max="1000.0" _gui-text="Width">100.0</param>
-			<param name="height" type="float" min="0.1" max="1000.0" _gui-text="Height">80.0</param>
-			<param name="innerradius" type="float" min="0.0" max="500.0" _gui-text="Corner radius">5.0</param>
-			<param name="units" _gui-text="Units" type="optiongroup" appearance="minimal">
-				<option value="px">px</option>
-				<option value="pt">pt</option>
-				<option value="in">in</option>
-				<option value="cm">cm</option>
-				<option value="mm">mm</option></param>
-			<param name="border" type="boolean" _gui-text="Outer Border">false</param>
-			<param name="borderwidth" type="float" min="0.0" max="500.0" _gui-text="    Border width">20.0</param>
-			<param name="outerradius" type="float" min="0.0" max="500.0" _gui-text="    Border radius">5.0</param>
-			<param name="pack" type="enum" _gui-text="    Pack Location">
-				<item value="Right">Right</item>
-				<item value="Below">Below</item>
-				<item value="Separate">Separate</item></param>
-			<param name="pieces_W" type="int" min="2" max="199" _gui-text="How many pieces across">5</param>
-			<param name="pieces_H" type="int" min="2" max="199" _gui-text="How many pieces down">4</param>
-		</page>
-		<page name="Notches" _gui-text="Notches">
-			<_param name="laserjignot" type="description" xml:space="preserve">Notches:
+            <param name="width" type="float" min="0.1" max="1000.0" _gui-text="Width">100.0</param>
+            <param name="height" type="float" min="0.1" max="1000.0" _gui-text="Height">80.0</param>
+            <param name="innerradius" type="float" min="0.0" max="500.0" _gui-text="Corner radius">5.0</param>
+            <param name="units" _gui-text="Units" type="optiongroup" appearance="minimal">
+                <option value="px">px</option>
+                <option value="pt">pt</option>
+                <option value="in">in</option>
+                <option value="cm">cm</option>
+                <option value="mm">mm</option>
+            </param>
+            <param name="border" type="boolean" _gui-text="Outer Border">false</param>
+            <param name="borderwidth" type="float" min="0.0" max="500.0" _gui-text="    Border width">20.0</param>
+            <param name="outerradius" type="float" min="0.0" max="500.0" _gui-text="    Border radius">5.0</param>
+            <param name="pack" type="enum" _gui-text="    Pack Location">
+                <item value="Right">Right</item>
+                <item value="Below">Below</item>
+                <item value="Separate">Separate</item>
+            </param>
+            <param name="pieces_W" type="int" min="2" max="199" _gui-text="How many pieces across">5</param>
+            <param name="pieces_H" type="int" min="2" max="199" _gui-text="How many pieces down">4</param>
+        </page>
+        <page name="Notches" _gui-text="Notches">
+            <_param name="laserjignot" type="description" xml:space="preserve">Notches:
 The interlocking pieces can be shaped here.
 Also the random nature of the layout.
 			</_param>
-			<param name="notch_percent" type="float" min="0.0" max="1.0" _gui-text="Notch relative size">0.5</param>
-			<param name="rand" type="float" min="0.0" max="1.0" _gui-text="Grid Randomisation">0.4</param>
-			<param name="smooth_edges" type="boolean" _gui-text="Some edges can be smooth">False</param>
-			<param name="noknob_frequency" type="float" min="0.0" max="100.0" _gui-text="   percentage of smooth edges">10</param>			
-			<param name="use_seed" type="boolean" _gui-text="Random jigsaw">True</param>
-			<param name="seed" type="int" min="0" max="99999999" _gui-text="   or Jigsaw pattern (seed)">12345</param>
-			<_param name="laserjigspace" type="description" xml:space="preserve">
+            <param name="notch_percent" type="float" min="0.0" max="1.0" _gui-text="Notch relative size">0.5</param>
+            <param name="rand" type="float" min="0.0" max="1.0" _gui-text="Grid Randomisation">0.4</param>
+            <param name="smooth_edges" type="boolean" _gui-text="Some edges can be smooth">False</param>
+            <param name="noknob_frequency" type="float" min="0.0" max="100.0" _gui-text="   percentage of smooth edges">10</param>
+            <param name="use_seed" type="boolean" _gui-text="Random jigsaw">True</param>
+            <param name="seed" type="int" min="0" max="99999999" _gui-text="   or Jigsaw pattern (seed)">12345</param>
+            <_param name="laserjigspace" type="description" xml:space="preserve">
 Empty
 			</_param>
-			<param name="pieces" type="boolean" _gui-text="Create pieces as well (-experimental)">false</param>
-		</page>
-		<page name="Usage" _gui-text="Usage">
-			<_param name="laserjiguse" type="description" xml:space="preserve">Lasercut Jigsaw:
+            <param name="pieces" type="boolean" _gui-text="Create pieces as well (-experimental)">false</param>
+        </page>
+        <page name="Usage" _gui-text="Usage">
+            <_param name="laserjiguse" type="description" xml:space="preserve">Lasercut Jigsaw:
 			
 Jigsaw lines are single for minimal laser cutting.
    (The pieces are not discrete shapes.)
@@ -67,15 +69,17 @@ Adjust Notch size and Randomization to avoid overlapping lines:
 	
 	
 		</_param>
-		</page>
-	</param>
-	<effect>
-		<object-type>all</object-type>
-		<effects-menu>
-			<submenu _name="Render"/>
-		</effects-menu>
-	</effect>
-	<script>
-		<command reldir="extensions" interpreter="python">Lasercut-jigsaw.py</command>
-	</script>
+        </page>
+    </param>
+    <effect>
+        <object-type>all</object-type>
+        <effects-menu>
+            <submenu _name="FabLab Chemnitz">
+				<submenu _name="Shape/Pattern from Generator"/>
+			</submenu>
+        </effects-menu>
+    </effect>
+    <script>
+        <command reldir="extensions" interpreter="python">fablabchemnitz_lasercut_jigsaw.py</command>
+    </script>
 </inkscape-extension>

--- a/Lasercut-jigsaw.inx
+++ b/Lasercut-jigsaw.inx
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <inkscape-extension xmlns="http://www.inkscape.org/namespace/inkscape/extension">
     <_name>Lasercut Jigsaw</_name>
-    <id>fablabchemnitz.de.lasercut_jigsaw</id>
+    <id>org.inkscape.render.LasercutJigsaw</id>
     <dependency type="executable" location="extensions">fablabchemnitz_lasercut_jigsaw.py</dependency>
     <dependency type="executable" location="extensions">inkex.py</dependency>
     <param name="tab" type="notebook">
@@ -74,12 +74,10 @@ Adjust Notch size and Randomization to avoid overlapping lines:
     <effect>
         <object-type>all</object-type>
         <effects-menu>
-            <submenu _name="FabLab Chemnitz">
-				<submenu _name="Shape/Pattern from Generator"/>
-			</submenu>
+	    <submenu _name="Shape/Pattern from Generator"/>
         </effects-menu>
     </effect>
     <script>
-        <command reldir="extensions" interpreter="python">fablabchemnitz_lasercut_jigsaw.py</command>
+        <command reldir="extensions" interpreter="python">lasercut_jigsaw.py</command>
     </script>
 </inkscape-extension>

--- a/Lasercut-jigsaw.py
+++ b/Lasercut-jigsaw.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#!/usr/bin/env python3
 '''
 Copyright (C) 2011 Mark Schafer <neon.mark (a) gmail dot com>
 
@@ -37,8 +37,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 __version__ = "0.3"
 
-import inkex, simplestyle, simpletransform
-from simplepath import *
+import inkex
 import sys, math, random, copy
 from lxml import etree
 from inkex.paths import Path, CubicSuperPath
@@ -119,7 +118,7 @@ class LasercutJigsaw(inkex.Effect):
         self.arg_parser.add_argument("-b", "--border", type=inkex.Boolean, default=False, help="Add Outer Surround")
         self.arg_parser.add_argument("-a", "--borderwidth", type=float, default=10.0, help="Size of external surrounding border.")
         self.arg_parser.add_argument("-o", "--outerradius", type=float, default=5.0, help="0 implies square corners")
-        self.arg_parser.add_argument("-p", "--pack", type=str, default="Below", help="Where to place backing piece on page")
+        self.arg_parser.add_argument("-p", "--pack", default="Below", help="Where to place backing piece on page")
         self.arg_parser.add_argument("-g", "--use_seed", type=inkex.Boolean, default=False, help="Use the kerf value as the drawn line width")
         self.arg_parser.add_argument("-s", "--seed", type=int, default=12345, help="Random seed for repeatability")
         self.arg_parser.add_argument("-j", "--pieces", type=inkex.Boolean, default=False, help="Make extra pieces for manual boolean separation.")
@@ -134,7 +133,6 @@ class LasercutJigsaw(inkex.Effect):
                            'stroke-width': self.stroke_width,
                            'stroke-linecap': 'butt',
                            'stroke-linejoin': 'miter'}
-
 
     def add_jigsaw_horiz_line(self, startx, starty, stepx, steps, width, style, name, parent):
         """ complex version All C smooth
@@ -427,5 +425,4 @@ class LasercutJigsaw(inkex.Effect):
             # needs manual boolean ops until that is exposed or we get all the commented code working up top :-(
        
 if __name__ == '__main__':
-    e = LasercutJigsaw()
-    e.run()
+    LasercutJigsaw().run()

--- a/Lasercut-jigsaw.py
+++ b/Lasercut-jigsaw.py
@@ -40,6 +40,8 @@ __version__ = "0.3"
 import inkex, simplestyle, simpletransform, cubicsuperpath
 from simplepath import *
 import sys, math, random, copy
+from lxml import etree
+from inkex import paths
 
 def randomize(x_y, radius, norm=True, absolute=False):
     """ return x,y moved by a random amount inside a radius.
@@ -87,11 +89,11 @@ def add_rounded_rectangle(startx, starty, radius, width, height, style, name, pa
             line_path.append(['l', [width, 0, 0, height, -width, 0, 0, -height]])
     #
     #sys.stderr.write("%s\n"% line_path)
-    attribs = {'style':simplestyle.formatStyle(style),
+    attribs = {'style':str(inkex.Style(style)),
                     inkex.addNS('label','inkscape'):name,
-                    'd':formatPath(line_path)}
+                    'd':str(paths.Path(paths.CubicSuperPath(line_path).to_path().to_arrays()))}
     #sys.stderr.write("%s\n"% attribs)
-    inkex.etree.SubElement(parent, inkex.addNS('path','svg'), attribs )
+    etree.SubElement(parent, inkex.addNS('path','svg'), attribs )
 
 
 
@@ -522,77 +524,77 @@ class LasercutJigsaw(inkex.Effect):
 
     def __init__(self):
         inkex.Effect.__init__(self)
-        self.OptionParser.add_option("-x", "--width",
-                        action="store", type="float",
+        self.arg_parser.add_argument("-x", "--width",
+                        action="store", type=float,
                         dest="width", default=50.0,
                         help="The Box Width - in the X dimension")
-        self.OptionParser.add_option("-y", "--height",
-                        action="store", type="float",
+        self.arg_parser.add_argument("-y", "--height",
+                        action="store", type=float,
                         dest="height", default=30.0,
                         help="The Box Height - in the Y dimension")
-        self.OptionParser.add_option("-u", "--units",
-                        action="store", type="string",
+        self.arg_parser.add_argument("-u", "--units",
+                        action="store", type=str,
                         dest="units", default="cm",
                         help="The unit of the box dimensions")
-        self.OptionParser.add_option("-w", "--pieces_W",
-                        action="store", type="int",
+        self.arg_parser.add_argument("-w", "--pieces_W",
+                        action="store", type=int,
                         dest="pieces_W", default=11,
                         help="How many pieces across")
-        self.OptionParser.add_option("-z", "--pieces_H",
-                        action="store", type="int",
+        self.arg_parser.add_argument("-z", "--pieces_H",
+                        action="store", type=int,
                         dest="pieces_H", default=11,
                         help="How many pieces down")
-        self.OptionParser.add_option("-k", "--notch_percent",
-                        action="store", type="float",
+        self.arg_parser.add_argument("-k", "--notch_percent",
+                        action="store", type=float,
                         dest="notch_percent", default=0.0,
                         help="Notch relative size. 0 to 1. 0.15 is good")
-        self.OptionParser.add_option("-r", "--rand",
-                        action="store", type="float",
+        self.arg_parser.add_argument("-r", "--rand",
+                        action="store", type=float,
                         dest="rand", default=0.1,
                         help="Amount to perturb the basic piece grid.")
-        self.OptionParser.add_option("-i", "--innerradius",
-                        action="store", type="float",
+        self.arg_parser.add_argument("-i", "--innerradius",
+                        action="store", type=float,
                         dest="innerradius", default=5.0,
                         help="0 implies square corners")
-        self.OptionParser.add_option("-b", "--border",
-                        action="store", type="inkbool",
+        self.arg_parser.add_argument("-b", "--border",
+                        action="store", type=inkex.Boolean,
                         dest="border", default=False,
                         help="Add Outer Surround")
-        self.OptionParser.add_option("-a", "--borderwidth",
-                        action="store", type="float",
+        self.arg_parser.add_argument("-a", "--borderwidth",
+                        action="store", type=float,
                         dest="borderwidth", default=10.0,
                         help="Size of external surrounding border.")
-        self.OptionParser.add_option("-o", "--outerradius",
-                        action="store", type="float",
+        self.arg_parser.add_argument("-o", "--outerradius",
+                        action="store", type=float,
                         dest="outerradius", default=5.0,
                         help="0 implies square corners")
-        self.OptionParser.add_option("-p", "--pack",
-                        action="store", type="string",
+        self.arg_parser.add_argument("-p", "--pack",
+                        action="store", type=str,
                         dest="pack", default="Below",
                         help="Where to place backing piece on page")
-        self.OptionParser.add_option("-g", "--use_seed",
-                        action="store", type="inkbool",
+        self.arg_parser.add_argument("-g", "--use_seed",
+                        action="store", type=inkex.Boolean,
                         dest="use_seed", default=False,
                         help="Use the kerf value as the drawn line width")
-        self.OptionParser.add_option("-s", "--seed",
-                        action="store", type="int",
+        self.arg_parser.add_argument("-s", "--seed",
+                        action="store", type=int,
                         dest="seed", default=12345,
                         help="Random seed for repeatability")
-        self.OptionParser.add_option("-j", "--pieces",
-                        action="store", type="inkbool",
+        self.arg_parser.add_argument("-j", "--pieces",
+                        action="store", type=inkex.Boolean,
                         dest="pieces", default=False,
                         help="Make extra pieces for manual boolean separation.")
-        self.OptionParser.add_option("-n", "--smooth_edges",
-                        action="store", type="inkbool",
+        self.arg_parser.add_argument("-n", "--smooth_edges",
+                        action="store", type=inkex.Boolean,
                         dest="smooth_edges", default=False,
                         help="Allow pieces with smooth edges.")
-        self.OptionParser.add_option("-f", "--noknob_frequency",
-                        action="store", type="float",
+        self.arg_parser.add_argument("-f", "--noknob_frequency",
+                        action="store", type=float,
                         dest="noknob_frequency", default=10,
                         help="Percentage of smooth-sided edges.")						
         # dummy for the doc tab - which is named
-        self.OptionParser.add_option("--tab",
-                        action="store", type="string", 
+        self.arg_parser.add_argument("--tab",
+                        action="store", type=str, 
                         dest="tab", default="use",
                         help="The selected UI-tab when OK was pressed")
         # internal useful variables
@@ -665,9 +667,9 @@ class LasercutJigsaw(inkex.Effect):
         clist.extend([width, starty, width, starty]) # doubled up at end for smooth curve
         line_path.append(['C',clist])
         #sys.stderr.write("%s\n"% line_path)
-        line_style = simplestyle.formatStyle(style)
-        attribs = { 'style':line_style, 'id':name, 'd':formatPath(line_path) }
-        inkex.etree.SubElement(parent, inkex.addNS('path','svg'), attribs )
+        line_style = str(inkex.Style(style))
+        attribs = { 'style':line_style, 'id':name, 'd':str(paths.Path(paths.CubicSuperPath(line_path).to_path().to_arrays()))}
+        etree.SubElement(parent, inkex.addNS('path','svg'), attribs )
 
     def create_horiz_blocks(self, group, gridy, style):
         path = lastpath = 0
@@ -692,7 +694,7 @@ class LasercutJigsaw(inkex.Effect):
                     #
                     name = "RowPieces_%d" % (count)
                     attribs = { 'style':style, 'id':name, 'd':spath }
-                    n = inkex.etree.SubElement(group, inkex.addNS('path','svg'), attribs )
+                    n = etree.SubElement(group, inkex.addNS('path','svg'), attribs )
                     blocks.append(n) # for direct traversal later
                 else: # internal line - concat a reversed version with the last one
                     thispath = copy.deepcopy(path)
@@ -701,8 +703,8 @@ class LasercutJigsaw(inkex.Effect):
                     thispath[0].reverse() # reverse the entire line
                     lastpath[0].extend(thispath[0]) # append
                     name = "RowPieces_%d" % (count)
-                    attribs = { 'style':style, 'id':name, 'd':cubicsuperpath.formatPath(lastpath) }
-                    n = inkex.etree.SubElement(group, inkex.addNS('path','svg'), attribs )
+                    attribs = { 'style':style, 'id':name, 'd':str(paths.Path(paths.CubicSuperPath(lastpath).to_path().to_arrays())) }
+                    n = etree.SubElement(group, inkex.addNS('path','svg'), attribs )
                     blocks.append(n) # for direct traversal later
                     n.set('d', n.get('d')+'z') # close it
                 #
@@ -722,7 +724,7 @@ class LasercutJigsaw(inkex.Effect):
         #
         name = "RowPieces_%d" % (count)
         attribs = { 'style':style, 'id':name, 'd':spath }
-        n = inkex.etree.SubElement(group, inkex.addNS('path','svg'), attribs )
+        n = etree.SubElement(group, inkex.addNS('path','svg'), attribs )
         blocks.append(n) # for direct traversal later
         #
         return(blocks)
@@ -751,7 +753,7 @@ class LasercutJigsaw(inkex.Effect):
                     #
                     name = "ColPieces_%d" % (count)
                     attribs = { 'style':style, 'id':name, 'd':spath }
-                    n = inkex.etree.SubElement(group, inkex.addNS('path','svg'), attribs )
+                    n = etree.SubElement(group, inkex.addNS('path','svg'), attribs )
                     blocks.append(n) # for direct traversal later
                 else: # internal line - concat a reversed version with the last one
                     thispath = copy.deepcopy(path)
@@ -760,8 +762,8 @@ class LasercutJigsaw(inkex.Effect):
                     thispath[0].reverse() # reverse the entire line
                     lastpath[0].extend(thispath[0]) # append
                     name = "ColPieces_%d" % (count)
-                    attribs = { 'style':style, 'id':name, 'd':cubicsuperpath.formatPath(lastpath) }
-                    n = inkex.etree.SubElement(group, inkex.addNS('path','svg'), attribs )
+                    attribs = { 'style':style, 'id':name, 'd':str(paths.Path(paths.CubicSuperPath(lastpath).to_path().to_arrays())) }
+                    n = etree.SubElement(group, inkex.addNS('path','svg'), attribs )
                     blocks.append(n) # for direct traversal later
                     n.set('d', n.get('d')+'z') # close it
                 #
@@ -781,7 +783,7 @@ class LasercutJigsaw(inkex.Effect):
         #
         name = "ColPieces_%d" % (count)
         attribs = { 'style':style, 'id':name, 'd':spath }
-        n = inkex.etree.SubElement(group, inkex.addNS('path','svg'), attribs )
+        n = etree.SubElement(group, inkex.addNS('path','svg'), attribs )
         blocks.append(n) # for direct traversal later
         #
         return(blocks)
@@ -794,8 +796,8 @@ class LasercutJigsaw(inkex.Effect):
         # Create new group
         g_attribs = {inkex.addNS('label','inkscape'):'JigsawPieces:X' + \
                      str( self.pieces_W )+':Y'+str( self.pieces_H ) }
-        jigsaw_pieces = inkex.etree.SubElement(jigsaw, 'g', g_attribs)
-        line_style = simplestyle.formatStyle(self.line_style)
+        jigsaw_pieces = etree.SubElement(jigsaw, 'g', g_attribs)
+        line_style = str(inkex.Style(self.line_style))
         #
         xblocks = self.create_horiz_blocks(jigsaw_pieces, gridy, line_style)
         #sys.stderr.write("count: %s\n"% dir(gridx))
@@ -819,11 +821,11 @@ class LasercutJigsaw(inkex.Effect):
     ### The main function called by the Inkscape UI
     def effect(self):
         # document dimensions (for centering)
-        docW = self.unittouu(self.document.getroot().get('width'))
-        docH = self.unittouu(self.document.getroot().get('height'))
+        docW = self.svg.unittouu(self.document.getroot().get('width'))
+        docH = self.svg.unittouu(self.document.getroot().get('height'))
         # extract fields from UI
-        self.width  = self.unittouu( str(self.options.width)  + self.options.units )
-        self.height  = self.unittouu( str(self.options.height) + self.options.units )
+        self.width  = self.svg.unittouu( str(self.options.width)  + self.options.units )
+        self.height  = self.svg.unittouu( str(self.options.height) + self.options.units )
         self.pieces_W = self.options.pieces_W
         self.pieces_H = self.options.pieces_H
         average_block = (self.width/self.pieces_W + self.height/self.pieces_H) / 2
@@ -848,13 +850,13 @@ class LasercutJigsaw(inkex.Effect):
         # set up the main object in the current layer - group gridlines
         g_attribs = {inkex.addNS('label','inkscape'):'Jigsaw:X' + \
                      str( self.pieces_W )+':Y'+str( self.pieces_H ) }
-        jigsaw_group = inkex.etree.SubElement(self.current_layer, 'g', g_attribs)
+        jigsaw_group = etree.SubElement(self.svg.get_current_layer(), 'g', g_attribs)
         #Group for X grid
         g_attribs = {inkex.addNS('label','inkscape'):'X_Gridlines'}
-        gridx = inkex.etree.SubElement(jigsaw_group, 'g', g_attribs)
+        gridx = etree.SubElement(jigsaw_group, 'g', g_attribs)
         #Group for Y grid
         g_attribs = {inkex.addNS('label','inkscape'):'Y_Gridlines'}
-        gridy = inkex.etree.SubElement(jigsaw_group, 'g', g_attribs)
+        gridy = etree.SubElement(jigsaw_group, 'g', g_attribs)
 
         # Draw the Border
         add_rounded_rectangle(0,0, self.inner_radius, self.width, self.height, self.line_style, 'innerborder', jigsaw_group)
@@ -902,4 +904,4 @@ class LasercutJigsaw(inkex.Effect):
 ###
 if __name__ == '__main__':
     e = LasercutJigsaw()
-    e.affect()
+    e.run()


### PR DESCRIPTION
hi. this is not working yet but i did some fixes regarding to Python3 migration. Maybe it helps a bit. stacktrace is 
```
Traceback (most recent call last):
  File "lasercut_jigsaw.py", line 907, in <module>
    e.run()
  File "C:\Users\inkscape-1.0-x64\share\inkscape\extensions\inkex\base.py", line 123, in run
    self.save_raw(self.effect())
  File "lasercut_jigsaw.py", line 883, in effect
    self.add_jigsaw_horiz_line(0, Ystep*i, Xstep, self.pieces_W, self.width, self.line_style, 'YDiv'+str(i), gridy)
  File "lasercut_jigsaw.py", line 671, in add_jigsaw_horiz_line
    attribs = { 'style':line_style, 'id':name, 'd':str(paths.Path(paths.CubicSuperPath(line_path).to_path().to_arrays()))}
  File "C:\Users\inkscape-1.0-x64\share\inkscape\extensions\inkex\paths.py", line 1269, in __init__
    self.append(item)
  File "C:\Users\inkscape-1.0-x64\share\inkscape\extensions\inkex\paths.py", line 1277, in append
    item = PathCommand.letter_to_class(item[0])(*item[1])
TypeError: __init__() takes exactly 7 arguments (607 given)
```